### PR TITLE
use master tag rather than latest

### DIFF
--- a/scripts/common
+++ b/scripts/common
@@ -10,9 +10,5 @@ else
     GIT_BRANCH=$TRAVIS_BRANCH
 fi
 
-if [ $GIT_BRANCH == "master" ]; then
-   GIT_BRANCH="latest"
-fi
-
 TAG_SHA="mrcide/${PACKAGE_NAME}:${GIT_SHA}"
 TAG_BRANCH="mrcide/${PACKAGE_NAME}:${GIT_BRANCH}"


### PR DESCRIPTION
Docker tags any untagged image with "latest", so it feels safer/less ambiguous to use explicit branch tags. This is the approach we take elsewhere.