### PR TITLE
MRC-554: avoid use of sleep in waiting for db

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgres:10.3
 COPY bin /hint-bin
-ENV PATH="hint-bin:$PATH"
+ENV PATH="/hint-bin:$PATH"
 ENV POSTGRES_DB hint
 ENV POSTGRES_USER hintuser
 ENV POSTGRES_PASSWORD changeme

--- a/bin/wait-for-db
+++ b/bin/wait-for-db
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+wait_for()
+{
+    echo "waiting up to $TIMEOUT seconds for postgres"
+    start_ts=$(date +%s)
+    for i in $(seq $TIMEOUT); do
+        # Using pg_ready as:
+        #
+        #   pg_isready -U $POSTGRES_USER -d $POSTGRES_DB
+        #
+        # seems heaps nicer but does not actually work properly
+        # because it pulls us up to soon.
+        psql -U $POSTGRES_USER -d $POSTGRES_DB -c "select 1;" > /dev/null 2>&1
+        result=$?
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echo "postgres is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+        echo "...still waiting"
+    done
+    return $result
+}
+
+# The variable expansion below is 100s by default, or the argument provided
+# to this script
+TIMEOUT="${1:-100}"
+wait_for
+RESULT=$?
+if [[ $RESULT -ne 0 ]]; then
+  echo "postgres did not become available in time"
+fi
+exit $RESULT

--- a/scripts/clear-docker.sh
+++ b/scripts/clear-docker.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-docker stop $(docker ps -aq)
-docker rm $(docker ps -aq)
+docker kill $(docker ps -aq) 2> /dev/null || true
+docker container prune --force
 docker network prune --force
 exit 0

--- a/scripts/run
+++ b/scripts/run
@@ -3,5 +3,5 @@ GIT_BRANCH=$(git -C "$PACKAGE_ROOT" symbolic-ref --short HEAD)
 docker run --rm -d --network=host --name hint-db mrcide/hint-db:$GIT_BRANCH
 
 # Need to give the database a little time to initialise before we can run the migration
-sleep 10s
+docker exec hint-db wait-for-db
 docker run --rm --network=host --name hint-db-migrate mrcide/hint-db-migrate:$GIT_BRANCH -url=jdbc:postgresql://localhost/hint

--- a/scripts/run
+++ b/scripts/run
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 GIT_BRANCH=$(git -C "$PACKAGE_ROOT" symbolic-ref --short HEAD)
 docker run --rm -d --network=host --name hint-db mrcide/hint-db:$GIT_BRANCH
 


### PR DESCRIPTION
This PR adds a new utility script `wait-for-db` (based on [`montagu-wait.sh`](https://github.com/vimc/montagu-db/blob/master/bin/montagu-wait.sh)) to wait for the db to come up, and uses it in the `run` script here.

This is needed to make the deployment more robust, as the sleep failed for me with slower hard disks, and will be excessive elsewhere