### PR TITLE
mrc-1165 Add type to session_file primary key

### DIFF
--- a/migrations/sql/V2019.12.04.1644__AddTypeToSessionFilePK.sql
+++ b/migrations/sql/V2019.12.04.1644__AddTypeToSessionFilePK.sql
@@ -1,6 +1,6 @@
 ALTER TABLE session_file
-  DROP CONSTRAINT session_file_pk;
+  DROP CONSTRAINT session_file_pkey;
 
 ALTER TABLE session_file
-  ADD CONSTRAINT session_file_pk
+  ADD CONSTRAINT session_file_pkey
     PRIMARY KEY (session, hash, type);

--- a/migrations/sql/V2019.12.04.1644__AddTypeToSessionFilePK.sql
+++ b/migrations/sql/V2019.12.04.1644__AddTypeToSessionFilePK.sql
@@ -1,5 +1,5 @@
 ALTER TABLE session_file
-  DROP PRIMARY KEY;
+  DROP CONSTRAINT session_file_pk;
 
 ALTER TABLE session_file
   ADD CONSTRAINT session_file_pk

--- a/migrations/sql/V2019.12.04.1644__AddTypeToSessionFilePK.sql
+++ b/migrations/sql/V2019.12.04.1644__AddTypeToSessionFilePK.sql
@@ -1,0 +1,6 @@
+ALTER TABLE session_file
+  DROP PRIMARY KEY;
+
+ALTER TABLE session_file
+  ADD CONSTRAINT session_file_pk
+    PRIMARY KEY (session, hash, type);


### PR DESCRIPTION
This branch currently deployed to staging: https://naomi.dide.ic.ac.uk:10443

Test is whether you can upload the same file twice into different file types e.g. upload survey.csv as both the survey and ANC. Should get a 400 rather than a 500 for the second upload. 