### PR TITLE
mrc-1646 Added version and additional columns to user session

### DIFF
--- a/migrations/sql/V2020.06.25.1104__AddVersion.sql
+++ b/migrations/sql/V2020.06.25.1104__AddVersion.sql
@@ -6,10 +6,23 @@ CREATE TABLE version
     note TEXT
 );
 
-ALTER TABLE user_session
-ADD COLUMN version_id INTEGER references version (id),
-ADD COLUMN state TEXT,
-ADD COLUMN note TEXT,
-ADD COLUMN created TIMESTAMP WITHOUT TIME ZONE DEFAULT (now() at time zone 'utc'),
-ADD COLUMN updated TIMESTAMP WITHOUT TIME ZONE DEFAULT (now() at time zone 'utc'),
-ADD COLUMN deleted BOOLEAN DEFAULT FALSE;
+CREATE TABLE version_snapshot
+(
+    id TEXT PRIMARY KEY,
+    version_id INTEGER references version (id),
+    state TEXT,
+    note TEXT,
+    created TIMESTAMP WITHOUT TIME ZONE DEFAULT (now() at time zone 'utc'),
+    updated TIMESTAMP WITHOUT TIME ZONE DEFAULT (now() at time zone 'utc'),
+    deleted BOOLEAN DEFAULT FALSE
+)
+
+
+CREATE TABLE snapshot_file
+(
+    snapshot  TEXT references version_snapshot (id),
+    hash      TEXT references file (hash),
+    type      TEXT,
+    fileName  TEXT,
+    PRIMARY KEY (snapshot, hash, type)
+)

--- a/migrations/sql/V2020.06.25.1104__AddVersion.sql
+++ b/migrations/sql/V2020.06.25.1104__AddVersion.sql
@@ -15,7 +15,7 @@ CREATE TABLE version_snapshot
     created TIMESTAMP WITHOUT TIME ZONE DEFAULT (now() at time zone 'utc'),
     updated TIMESTAMP WITHOUT TIME ZONE DEFAULT (now() at time zone 'utc'),
     deleted BOOLEAN DEFAULT FALSE
-)
+);
 
 
 CREATE TABLE snapshot_file
@@ -25,4 +25,4 @@ CREATE TABLE snapshot_file
     type      TEXT,
     fileName  TEXT,
     PRIMARY KEY (snapshot, hash, type)
-)
+);

--- a/migrations/sql/V2020.06.25.1104__AddVersion.sql
+++ b/migrations/sql/V2020.06.25.1104__AddVersion.sql
@@ -1,0 +1,15 @@
+CREATE TABLE version
+(
+    id SERIAL,
+    user_id TEXT references users (id),
+    name TEXT NOT NULL,
+    note TEXT
+);
+
+ALTER TABLE user_session
+ADD COLUMN version_id INTEGER references version (id),
+ADD COLUMN state TEXT,
+ADD COLUMN note TEXT,
+ADD COLUMN created TIMESTAMP WITHOUT TIME ZONE DEFAULT (now() at time zone 'utc'),
+ADD COLUMN updated TIMESTAMP WITHOUT TIME ZONE DEFAULT (now() at time zone 'utc'),
+ADD COLUMN deleted BOOLEAN DEFAULT FALSE;

--- a/migrations/sql/V2020.06.25.1104__AddVersion.sql
+++ b/migrations/sql/V2020.06.25.1104__AddVersion.sql
@@ -1,6 +1,6 @@
 CREATE TABLE version
 (
-    id SERIAL,
+    id SERIAL PRIMARY KEY,
     user_id TEXT references users (id),
     name TEXT NOT NULL,
     note TEXT


### PR DESCRIPTION
Not all the new columns are used yet, but we'll be adding things like Note soon so I though I might as well add then now. Continuing to use the UserSession table, though that now holds data for what we're currently calling a version snapshot. The id is no longer coming from a session id, but a UUID kept in a session variable. 
State will hold the frontend JSON state for a snapshot so that it can later ber reloaded.  