### PR TITLE
mrc-1725 add snapshot_dataset table

### DIFF
--- a/migrations/sql/V2020.08.04.1450__AddSnapshotDataset.sql
+++ b/migrations/sql/V2020.08.04.1450__AddSnapshotDataset.sql
@@ -1,0 +1,7 @@
+CREATE TABLE snapshot_dataset
+(
+    snapshot TEXT PRIMARY KEY references version_snapshot (id),
+    id TEXT,
+    name TEXT,
+    last_modified TEXT
+);


### PR DESCRIPTION
We will need to record the top level selected ADR dataset against a snapshot. 

We will also need to modify the `snapshot_file` table either to include a record of which ADR dataset a file has come from (if we continue allowing selecting individual files from different datasets) or just a flag to determine whether a file has come from the ADR vs computer upload (if the former feature is scrapped.) Since the spec for the second part isn't pinned down I'm just leaving that for now.