### PR TITLE
mrc-1757 Add version number to project_version table

### DIFF
--- a/migrations/sql/V2020.09.02.1441__AddVersionNumberToProjectVersion.sql
+++ b/migrations/sql/V2020.09.02.1441__AddVersionNumberToProjectVersion.sql
@@ -1,0 +1,2 @@
+ALTER TABLE project_version
+  ADD COLUMN version_number INTEGER;


### PR DESCRIPTION
Generating a version number for versions purely in the front end isn't going to work because versions can be deleted and won't all make it back to the front end to show up in Project History. However, deleted versions are still in the database, so we should always be able to tell what version number a new version of a project should get, and save that in the database.